### PR TITLE
Additional changes for Region support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,16 +6,15 @@
 
 ### Breaking changes
 
-* It was necessary to change the physical resource ID for `Custom::SES_Domain` 
-  resources. As a result, `!Ref` will no longer return the domain name. If you 
-  have templates that use `!Ref MySESDomain` to get the domain, change them 
-  to `!GetAtt MySESDomain.Domain` instead. (You should not attempt to extract data 
-  from the new `!Ref` format.)
+* The physical resource ID of a `Custom::SES_Domain` resource is now the full ARN 
+  of the Amazon SES domain identity. (Previously it was just the domain name.)
+  If you have templates that use `!Ref MySESDomain` to get the domain, change them 
+  to `!GetAtt MySESDomain.Domain` instead.
 
 * Because of the physical resource ID change, the first stack update after upgrading
   to v0.3 will appear to update and then delete existing `Custom::SES_Domain` resources.
   Don't be alarmed: your SES domain *isn't* actually deleted. (The delete operation 
-  is related to the old physical resource ID, and is ignored.)
+  covers the old physical resource ID, and will be ignored.)
 
 ### Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,26 @@
 
 ## v0.3.dev0
 
-*(Development testing)*
+*Unreleased changes*
+
+### Breaking changes
+
+* It was necessary to change the physical resource ID for `Custom::SES_Domain` 
+  resources. As a result, `!Ref` will no longer return the domain name. If you 
+  have templates that use `!Ref MySESDomain` to get the domain, change them 
+  to `!GetAtt MySESDomain.Domain` instead. (You should not attempt to extract data 
+  from the new `!Ref` format.)
+
+* Because of the physical resource ID change, the first stack update after upgrading
+  to v0.3 will appear to update and then delete existing `Custom::SES_Domain` resources.
+  Don't be alarmed: your SES domain *isn't* actually deleted. (The delete operation 
+  is related to the old physical resource ID, and is ignored.)
+
+### Fixes
+
+* Support using the [`Region`](README.md#region) property to provision an Amazon SES 
+  domain in a different region from where you're running your CloudFormation stack.
+  (Thanks to @gfodor.)
 
 
 ## v0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,11 @@
   domain in a different region from where you're running your CloudFormation stack.
   (Thanks to @gfodor.)
 
+### Features
+
+* Make [`Arn`](README.md#other-attributes) and [`Region`](README.md#other-attributes)
+  attributes available on `Custom::SES_Domain` resources.
+
 
 ## v0.2
 

--- a/CustomSESDomainSpecification.json
+++ b/CustomSESDomainSpecification.json
@@ -85,6 +85,12 @@
         },
         "ReceiveMX": {
           "PrimitiveType": "String"
+        },
+        "Region": {
+          "PrimitiveType": "String"
+        },
+        "Arn": {
+          "PrimitiveType": "String"
         }
       }
     }

--- a/CustomSESDomainSpecification.json
+++ b/CustomSESDomainSpecification.json
@@ -49,7 +49,7 @@
           "Documentation": "https://github.com/medmunds/aws-cfn-ses-domain/blob/master/README.md#region",
           "PrimitiveType": "String",
           "Required": false,
-          "UpdateType": "Mutable"
+          "UpdateType": "Immutable"
         }
       },
       "Attributes": {

--- a/README.md
+++ b/README.md
@@ -283,11 +283,11 @@ lambda function is running.)
 #### Ref
 
 When a `Custom::SES_Domain` resource is provided to the `Ref` intrinsic function, 
-`Ref` returns an internal resource identifier. Your stack code should not make any
-assumptions about the format of this identifier, as it may change in future updates.
+`Ref` returns the Amazon Resource Name (ARN) of the Amazon SES domain identity 
+(e.g., `arn:aws:ses:us-east-1:111111111111:identity/example.com`).
 
-(Prior to v0.3, `!Ref MySESDomain` was documented to return the domain. This is no 
-longer true, and updated code should instead use `!GetAtt MySESDomain.Domain`.)
+*Changed in v0.3:* Earlier versions returned the domain (which is still available 
+as `!GetAtt MySESDomain.Domain`).
 
 
 #### Fn::GetAtt

--- a/README.md
+++ b/README.md
@@ -263,11 +263,10 @@ The time-to-live value to include in resulting DNS records (in seconds).
 
 ##### `Region`
 
-The AWS Region to use for determining Amazon SES [SMTP endpoints][ses-smtp-endpoints], 
-e.g., `"us-east-1"`.
-The default is the region where the `Custom::SES_Domain` resource is being provisioned.
-(This must be a region where Amazon SES is supported, and it's extremely unlikely you'd
-want to override this.)
+The AWS Region where your Amazon SES domain will be provisioned, e.g., `"us-east-1"`. 
+This must be a region where Amazon SES is supported. The default is the region where
+your CloudFormation stack is running (or technically, where the `Custom::SES_Domain` 
+lambda function is running.)
 
 *Required:* No
 
@@ -275,7 +274,7 @@ want to override this.)
 
 *Default:* `${AWS::Region}`
 
-*Update requires:* No interruption
+*Update requires:* Replacement
 
 
 
@@ -284,7 +283,11 @@ want to override this.)
 #### Ref
 
 When a `Custom::SES_Domain` resource is provided to the `Ref` intrinsic function, 
-`Ref` returns the [`Domain`](#domain) (without any trailing period).
+`Ref` returns an internal resource identifier. Your stack code should not make any
+assumptions about the format of this identifier, as it may change in future updates.
+
+(Prior to v0.3, `!Ref MySESDomain` was documented to return the domain. This is no 
+longer true, and updated code should instead use `!GetAtt MySESDomain.Domain`.)
 
 
 #### Fn::GetAtt

--- a/README.md
+++ b/README.md
@@ -378,6 +378,11 @@ may be helpful for generating custom DNS records or other purposes:
 * `ReceiveMX` (String): the inbound MX host to use for receiving email, e.g.,
   `inbound-smtp.us-east-1.amazonaws.com` 
   (not available if [`EnableReceive`](#enablereceive) is false) 
+* `Arn` (String): the Amazon Resource Name (ARN) of the provisioned Amazon SES 
+  domain identity (useful for delegating sending authorization; this is the same
+  value returned by [`!Ref MySESDomain`](#ref))
+* `Region` (String): the resolved [`Region`](#region) where the Amazon SES domain 
+  was provisioned 
 
 
 ### Validating Your Templates

--- a/aws-cfn-ses-domain.cf.yaml
+++ b/aws-cfn-ses-domain.cf.yaml
@@ -12,7 +12,7 @@ Parameters:
     Description: >
       The S3 bucket where the LAMBDA_ZIP deployment package
       has been uploaded. Must reside in the same AWS Region where your stack
-      will be provisioning SES domains.
+      is running.
   LambdaCodeS3Key:
     Type: String
     Default: YOUR_LAMBDA_ZIP_KEY

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -194,7 +194,7 @@ class TestLambdaHandler(TestCase):
 
     def test_update_receive_only(self):
         event = {
-            "RequestType": "Create",
+            "RequestType": "Update",
             "ResourceProperties": {
                 "Domain": "example.com.",
                 "EnableSend": False,
@@ -236,7 +236,7 @@ class TestLambdaHandler(TestCase):
     def test_delete(self):
         event = {
             "RequestType": "Delete",
-            "PhysicalResourceId": "example.com:mock-region",
+            "PhysicalResourceId": "arn:aws:ses:mock-region:111111111111:identity/example.com",
             "ResourceProperties": {
                 "Domain": "example.com.",
                 "EnableSend": True,

--- a/tests/test_lambda_handler.py
+++ b/tests/test_lambda_handler.py
@@ -121,6 +121,8 @@ class TestLambdaHandler(TestCase):
             'mail.example.com.                   \t1800\tIN\tTXT  \t"v=spf1 include:amazonses.com -all"',
             '_dmarc.example.com.                 \t1800\tIN\tTXT  \t"v=DMARC1; p=none; pct=100; sp=none; aspf=r;"',
         ])
+        self.assertEqual(outputs["Region"], "mock-region")
+        self.assertEqual(outputs["Arn"], "arn:aws:ses:mock-region:111111111111:identity/example.com")
 
     def test_create_all_options(self):
         event = {
@@ -187,6 +189,8 @@ class TestLambdaHandler(TestCase):
             '_dmarc.example.com.                 \t300\tIN\tTXT  \t"v=DMARC1; p=quarantine; rua=mailto:d@example.com;"',
             'example.com.                        \t300\tIN\tMX   \t10 inbound-smtp.us-test-2.amazonaws.com.',
         ])
+        self.assertEqual(outputs["Region"], "us-test-2")
+        self.assertEqual(outputs["Arn"], "arn:aws:ses:us-test-2:111111111111:identity/example.com")
 
     def test_update_receive_only(self):
         event = {


### PR DESCRIPTION
[@gfodor GitHub isn't letting me update your PR by pushing to it, and these changes are a little too complex to do in their web editor. So I'm attempting to open a pull request into your PR.]

* Change the PhysicalResourceId of the Custom::SES_Domain to be 
  the ARN of the SES domain identity. (This includes the Region in the ID,
  so that CloudFormation automatically handles region updates properly.)

* Add Region and Arn attributes

* Add some related tests

* Update docs, cfn-lint spec, and changelog
